### PR TITLE
Dev

### DIFF
--- a/api_endpoint/endpoint_methods/main.tf
+++ b/api_endpoint/endpoint_methods/main.tf
@@ -41,6 +41,7 @@ resource "aws_api_gateway_integration" "api_integration" {
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
   uri                     = aws_lambda_function.lambda_function.invoke_arn
+  timeout_milliseconds    = var.timeout * 1000
 }
 
 # ========== Cloudwatch ==========


### PR DESCRIPTION
timeout was missing on integration request, so it didn't work beyond 30 seconds (the default)